### PR TITLE
Real life config files; plotting and caching tweaks

### DIFF
--- a/configs/real_life.yaml
+++ b/configs/real_life.yaml
@@ -1,5 +1,6 @@
 tasks:
   - opening_or_closing/door
+  - object/small
 models:
   - kind: gpt
     n_frames: 5
@@ -18,7 +19,7 @@ models:
     encoder: s3d
     heads:
       - kind: cosine
-task_dir: /data/datasets/vlm_benchmark_evan/tasks/real_life
-video_dir: /data/datasets/vlm_benchmark_evan/videos/real_life
-cache_dir: /data/datasets/vlm_benchmark_evan/.cache
-output_dir: /data/datasets/vlm_benchmark_evan/experiments
+task_dir: /data/datasets/vlm_benchmark/tasks/real_life
+video_dir: /data/datasets/vlm_benchmark/videos/real_life
+cache_dir: /data/datasets/vlm_benchmark/.cache
+output_dir: /data/datasets/vlm_benchmark/experiments/evan

--- a/configs/real_life_mini.yaml
+++ b/configs/real_life_mini.yaml
@@ -1,8 +1,8 @@
 tasks:
-  - opening_or_closing/door
+  - opening_or_closing_mini/door
 models:
-  - kind: gpt
-    n_frames: 5
+#  - kind: gpt
+#    n_frames: 5
   - kind: encoder
     encoder: clip
     heads:

--- a/configs/real_life_mini.yaml
+++ b/configs/real_life_mini.yaml
@@ -1,8 +1,8 @@
 tasks:
   - opening_or_closing_mini/door
 models:
-#  - kind: gpt
-#    n_frames: 5
+  - kind: gpt
+    n_frames: 5
   - kind: encoder
     encoder: clip
     heads:
@@ -18,7 +18,7 @@ models:
     encoder: s3d
     heads:
       - kind: cosine
-task_dir: /data/datasets/vlm_benchmark_evan/tasks/real_life
-video_dir: /data/datasets/vlm_benchmark_evan/videos/real_life
-cache_dir: /data/datasets/vlm_benchmark_evan/.cache
-output_dir: /data/datasets/vlm_benchmark_evan/experiments
+task_dir: /data/datasets/vlm_benchmark/tasks/real_life
+video_dir: /data/datasets/vlm_benchmark/videos/real_life
+cache_dir: /data/datasets/vlm_benchmark/.cache
+output_dir: /data/datasets/vlm_benchmark/experiments/evan

--- a/src/vlm/plots.py
+++ b/src/vlm/plots.py
@@ -134,6 +134,7 @@ def task_performance(
         height=300 * nrows,
         showlegend=False,
         title=title,
+        coloraxis_colorscale="Purples",
     )
     fig.update_yaxes(range=[0, 1], row=1)
     return fig
@@ -174,16 +175,3 @@ def incorrect_video_labels(predictions: pl.DataFrame):
     df = incorrect_count.sort("count", descending=True)
 
     return df
-
-
-def confusion_matrix(data: pl.DataFrame):
-    # Compute confusion matrix
-    cm = skm.confusion_matrix(data["true_label"].to_numpy(), data["label"].to_numpy())
-
-    # Create heatmap
-    heatmap = px.imshow(
-        cm,
-        labels=dict(x="Predicted label", y="True label"),
-        color_continuous_scale="Viridis",
-    )
-    return heatmap


### PR DESCRIPTION
- Update the real life config file to include the small object recognition task
- Add a "mini" real life config file for fast and cheap testing
- Made all models, not just GPT-4, subsample the frames up front. (this is not redundant since other models may subsample more frames than GPT-4 (e.g. in our configuration CLIP samples 32 and GPT-4 samples 5))
- Removed dependence on "id" in the GPT-4 cache, since this information is not given to GPT-4 and therefore does not affect the outputs
- Switched the colormap for the confusion matrix to one where mostly the saturation rather than the hue is changing, since Viridis is hard to interpret when there are only 4 entries in the confusion matrix
- Add a little more logging during video loading and prediction so it's easier to see what's taking the most time and whether the cache is being used
- Delete unused function `confusion_matrix`